### PR TITLE
Improved robustness for proccessing GenomeScan batches.

### DIFF
--- a/etc/umcg-genomescan-extend.cfg
+++ b/etc/umcg-genomescan-extend.cfg
@@ -1,3 +1,3 @@
 DATA_MANAGER="umcg-gd-dm"
-SCR_ROOT_DIR="/groups/umcg-genomescan/${TMP_LFS}/"
+SCR_ROOT_DIR="/groups/${GROUP}/${TMP_LFS}/"
 PRM_ROOT_DIR="/groups/umcg-gd/${PRM_LFS}"

--- a/etc/umcg-genomescan.cfg
+++ b/etc/umcg-genomescan.cfg
@@ -1,9 +1,7 @@
 GROUP='umcg-genomescan'
 declare -a NOTIFY_FOR_PHASE_WITH_STATE=(
+	'processGsRawData:failed'
+	'processGsRawData:finished'
 	'copyRawDataToPrm:failed'
 	'copyRawDataToPrm:finished'
-	'pipeline:failed'
-	'pipeline:gendercheckfailed'
-	'copyProjectDataToPrm:failed'
-	'copyProjectDataToPrm:finished'
 )


### PR DESCRIPTION
* etc/umcg-genomescan-extend.cfg: Use ${GROUP} var for default group. (Use hardcoded group values only for the execptions.)
* etc/umcg-genomescan.cfg: Updated email notification config to send notifycations for state of relevant analysis steps.
* processGsRawData.sh:
  * Run script as ateambot user without write acces to prm as opposed to dm user with write access to prm.
  * Reset *.started files.
  * Convert dos/win/mac line end charaters in samplesheets to unix format.
  * Remove empty lines from samplesheets.
  * Ensure last line in samplesheet contains line end character.
