### PR TITLE
Proper handling of situation when there are no samplesheets to process.

### DIFF
--- a/bin/copyRawDataToPrm.sh
+++ b/bin/copyRawDataToPrm.sh
@@ -563,11 +563,11 @@ log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "Log files will be written 
 #	1. loop over their analysis ("run") sub dirs and check if there are any we need to rsync.
 #	2. split the sample sheets per project and the data was rsynced.
 #
-IFS=$'\n' sampleSheetsFromSourceServer=($(ssh ${DATA_MANAGER}@${sourceServerFQDN} "ls -1 ${SCR_ROOT_DIR}/Samplesheets/*.${SAMPLESHEET_EXT}"))
+IFS=$'\n' sampleSheetsFromSourceServer=($(ssh ${DATA_MANAGER}@${sourceServerFQDN} "find ${SCR_ROOT_DIR}/Samplesheets/ -mindepth 1 -maxdepth 1 \( -type l -o -type f \) -name *.${SAMPLESHEET_EXT}"))
 
 if [[ "${#sampleSheetsFromSourceServer[@]:-0}" -eq '0' ]]
 then
-	log4Bash 'WARN' "${LINENO}" "${FUNCNAME:-main}" '0' "No sample sheets found for ${DATA_MANAGER}@${sourceServerFQDN}:${SCR_ROOT_DIR}/Samplesheets/*.${SAMPLESHEET_EXT}."
+	log4Bash 'WARN' "${LINENO}" "${FUNCNAME:-main}" '0' "No sample sheets found at ${DATA_MANAGER}@${sourceServerFQDN}:${SCR_ROOT_DIR}/Samplesheets/*.${SAMPLESHEET_EXT}."
 else
 	for sampleSheet in "${sampleSheetsFromSourceServer[@]}"
 	do

--- a/etc/cron.d/boxy.umcg-gd-dm.cron
+++ b/etc/cron.d/boxy.umcg-gd-dm.cron
@@ -5,7 +5,7 @@
 # As the code currently creates a lock file per group to prevent running multiple instances simultaneously,
 # we need to separate these cron jobs in time to make sure they both have a chance of running.
 #
-#*/10 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.15-bare; copyRawDataToPrm.sh -g umcg-gd -s zf-ds.gcc.rug.nl      -r /groups/umcg-genomescan/tmp05"
-#*/10 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.15-bare; copyRawDataToPrm.sh -g umcg-gd -s gattaca02.gcc.rug.nl"
-0,20,40 * * * *  /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.15-bare; copyRawDataToPrm.sh -g umcg-gd -s zf-ds.gcc.rug.nl      -r /groups/umcg-genomescan/tmp05"
-10,30,50 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.15-bare; copyRawDataToPrm.sh -g umcg-gd -s gattaca02.gcc.rug.nl"
+#*/10 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.16-bare; copyRawDataToPrm.sh -g umcg-gd -s zf-ds.gcc.rug.nl      -r /groups/umcg-genomescan/tmp05"
+#*/10 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.16-bare; copyRawDataToPrm.sh -g umcg-gd -s gattaca02.gcc.rug.nl"
+0,20,40 * * * *  /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.16-bare; copyRawDataToPrm.sh -g umcg-gd -s zf-ds.gcc.rug.nl      -r /groups/umcg-genomescan/tmp05"
+10,30,50 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.16-bare; copyRawDataToPrm.sh -g umcg-gd -s gattaca02.gcc.rug.nl"

--- a/etc/cron.d/zinc-finger.umcg-genomescan-ateambot.cron
+++ b/etc/cron.d/zinc-finger.umcg-genomescan-ateambot.cron
@@ -1,2 +1,2 @@
-*/30 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.10-bare; processGsRawData.sh     -g umcg-genomescan"
-*/15 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.10-bare; notifications.sh        -g umcg-genomescan -e"
+*/15 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.16-bare; processGsRawData.sh -g umcg-genomescan"
+*/15 * * * * /bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; module load NGS_Automated/2.0.16-bare; notifications.sh -e -g umcg-genomescan"


### PR DESCRIPTION
* ```copyRawDataToPrm.sh``` and ```startPipeline.sh```
   * Fixed bugs that would cause a FATAL error when no samplesheets are present. For ```startPipeline.sh``` this was previously changed, but that resulted in getting no more errors at all also not when things really go wrong resulting in bug #106. This commit fixes #106.
   * Fixed some indentation/formatting.
* Updated several cron jobs for new release.