### PR TITLE
Minor cleanup and improved robustness for parsing crappy *.csv files.

### DIFF
--- a/bin/copyRawDataToPrm.sh
+++ b/bin/copyRawDataToPrm.sh
@@ -251,7 +251,7 @@ function splitSamplesheetPerProject() {
 	local _sampleSheet="${PRM_ROOT_DIR}/Samplesheets/archive/${_run}.${SAMPLESHEET_EXT}"
 	#
 	# ToDo: change location of job control files back to ${TMP_ROOT_DIR} once we have a 
-	#       proper prm mount on the GD clusters and this script can run a GD cluster
+	#       proper prm mount on the GD clusters and this script can run on a GD cluster
 	#       instead of on a research cluster.
 	#
 	#local JOB_CONTROLE_FILE_BASE="${TMP_ROOT_DIR}/logs/${_run}/${_run}.splitSamplesheetPerProject"
@@ -370,7 +370,7 @@ function splitSamplesheetPerProject() {
 		else
 		#
 		# ToDo: change location of sample sheet per project back to ${TMP_ROOT_DIR} once we have a 
-		#       proper prm mount on the GD clusters and this script can run a GD cluster
+		#       proper prm mount on the GD clusters and this script can run on a GD cluster
 		#       instead of on a research cluster.
 		#
 		#local _projectSampleSheet="${TMP_ROOT_DIR}/Samplesheets/${_project}.${SAMPLESHEET_EXT}"

--- a/bin/processGsRawData.sh
+++ b/bin/processGsRawData.sh
@@ -470,7 +470,6 @@ function renameFastQs() {
 
 function processSamplesheetsAndMoveCovertedData() {
 	local _batch="${1}"
-	local _sampleSheet="${TMP_ROOT_DIR}/Samplesheets/archive/${_batch}.${SAMPLESHEET_EXT}"
 	local _controlFileBase="${2}"
 	local _controlFileBaseForFunction="${_controlFileBase}.${FUNCNAME}"
 	local _logFile="${_controlFileBaseForFunction}.log"

--- a/bin/processGsRawData.sh
+++ b/bin/processGsRawData.sh
@@ -81,7 +81,7 @@ function sanityChecking() {
 		# Make sure:
 		#  1. The last line ends with a line end character.
 		#  2. We have the right line end character: convert any carriage return (\r) to newline (\n).
-		#  3. We remove empty lines.
+		#  3. We remove empty lines: lines containing only white space and/or field separators are considered empty too.
 		#
 		cp "${_gsSampleSheet}"{,.converted} \
 			2>> "${_controlFileBaseForFunction}.started" \
@@ -90,7 +90,7 @@ function sanityChecking() {
 			>> "${_gsSampleSheet}.converted" \
 			&& sed -i 's/\r/\n/g' "${_gsSampleSheet}.converted" \
 			2>> "${_controlFileBaseForFunction}.started" \
-			&& sed -i '/^\s*$/d' "${_gsSampleSheet}.converted" \
+			&& sed -i "/^[\s${SAMPLESHEET_SEP}]*$/d" "${_gsSampleSheet}.converted" \
 			2>> "${_controlFileBaseForFunction}.started" \
 			&& mv -f "${_gsSampleSheet}"{.converted,} \
 			2>> "${_controlFileBaseForFunction}.started" \
@@ -258,7 +258,7 @@ function sanityChecking() {
 			# Make sure
 			#  1. The last line ends with a line end character.
 			#  2. We have the right line end character: convert any carriage return (\r) to newline (\n).
-			#  3. We remove empty lines.
+			#  3. We remove empty lines: lines containing only white space and/or field separators are considered empty too.
 			#
 			cp "${_sampleSheet}"{,.converted} \
 				2>> "${_controlFileBaseForFunction}.started" \
@@ -267,7 +267,7 @@ function sanityChecking() {
 				>> "${_sampleSheet}.converted" \
 				&& sed -i 's/\r/\n/g' "${_sampleSheet}.converted" \
 				2>> "${_controlFileBaseForFunction}.started" \
-				&& sed -i '/^\s*$/d' "${_sampleSheet}.converted" \
+				&& sed -i "/^[\s${SAMPLESHEET_SEP}]*$/d" "${_sampleSheet}.converted" \
 				2>> "${_controlFileBaseForFunction}.started" \
 				&& mv -f "${_sampleSheet}"{.converted,} \
 				2>> "${_controlFileBaseForFunction}.started" \


### PR DESCRIPTION
* Fixed typo in comment.
* Removed unused ```_sampleSheet``` variable from ```processSamplesheetsAndMoveCovertedData()``` function.
* Prevent processing of *.csv files from crashing on "empty" lines that do contain one or more field separators, but no actual data.