### PR TITLE
Make the indentationcheck.sh work when executed from anywhere on the file system. 

### DIFF
--- a/check/indentationcheck.sh
+++ b/check/indentationcheck.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+#
+# Use either WORKSPACE location for Jenkins or
+# resolve path to scripts we need to check
+# when executed manualy outside Jenkins.
+#
+if [[ -z "${WORKSPACE:-}" ]]; then
+	MYDIR="$(cd -P "$(dirname "${0}")" && pwd)"
+	WORKSPACE="$(dirname ${MYDIR})"
+fi
+
 echo '#####################################################################################'
 echo '  Bash code must be indented with TABs. Checking for lines indented with spaces ... '
 echo '#####################################################################################'


### PR DESCRIPTION
Before this addition it would only work from the ```check``` subdir.