### PR TITLE
Bugfix for processGsRawData.sh

### DIFF
--- a/bin/createInhouseSamplesheetFromGS.py
+++ b/bin/createInhouseSamplesheetFromGS.py
@@ -216,11 +216,11 @@ if args.samplesheetsOutputDir == args.inhouseSamplesheetsInputDir:
 #
 # Check availability and readability of GS samplesheet.
 #
-for gsSamplesheetFile in glob.iglob(os.path.join(args.genomeScanInputDir, "CSV_UMCG_*.csv")):
+for gsSamplesheetFile in glob.iglob(os.path.join(args.genomeScanInputDir, "CSV_UMCG_*.csv.converted")):
     if os.path.isfile(gsSamplesheetFile) and os.access(gsSamplesheetFile, os.R_OK):
         logging.info('Found GenomeScan samplesheet: ' + gsSamplesheetFile + '.')
     else:
-        logging.critical('Either the ' + args.genomeScanInputDir + 'CSV_UMCG_*.csv file is missing or it is not readable.')
+        logging.critical('Either the ' + args.genomeScanInputDir + 'CSV_UMCG_*.csv.converted file is missing or it is not readable.')
         sys.exit('FATAL ERROR!')
 #
 # Check availability and readability of md5sum file.

--- a/bin/createInhouseSamplesheetFromGS.py
+++ b/bin/createInhouseSamplesheetFromGS.py
@@ -237,6 +237,11 @@ else:
 # Get sequencing meta-data from original filenames as listed in the checksum file.
 #
 gsFilenameDataHashmap = makeOriginalFilenameHashmap(checksumsFilePath)
+# For debugging data structure only:
+import pprint
+pp = pprint.PrettyPrinter(indent=4)
+pp.pprint(gsFilenameDataHashmap)
+pp.pprint('=====================================================')
 
 #
 # Combine GS samplesheet with original filename information form gsFilenameDataHashmap.
@@ -285,6 +290,7 @@ for row in gsReader:
     gsGenomeScanID=row['GS_ID']
     gsProjects.append(gsProject)
     gsBarcodesAndGenomeScanID = row['Index1'] + '-' + row['Index2'] + '-' + gsGenomeScanID
+    logging.debug('Compiled gsBarcodesAndGenomeScanID key ' + gsBarcodesAndGenomeScanID + ' for lookup of values in gsFilenameDataHashmap.')
     if gsSamplesheetDataHashmap.has_key(gsSampleProcessStepID):
         logging.critical('sampleProcessStepID ' + gsSampleProcessStepID + ' is not uniq in project ' + gsProject + '.')
         sys.exit('FATAL ERROR!')

--- a/bin/createInhouseSamplesheetFromGS.py
+++ b/bin/createInhouseSamplesheetFromGS.py
@@ -306,10 +306,10 @@ for row in gsReader:
             'FastQs': gsFilenameDataHashmap[gsBarcodesAndGenomeScanID]
         }
         # For debugging data structure only:
-        #import pprint
-        #pp = pprint.PrettyPrinter(indent=4)
-        #pp.pprint(gsSamplesheetDataHashmap)
-        #pp.pprint('#####################################################')
+        import pprint
+        pp = pprint.PrettyPrinter(indent=4)
+        pp.pprint(gsSamplesheetDataHashmap)
+        pp.pprint('#####################################################')
     except:
         logging.critical('Meta data parsed from original FastQ filenames as supplied by GenomeScan missing for sample ' + gsGenomeScanID + ' with barcodes ' + row['Index1'] + '-' + row['Index2'] + ' from project ' + gsProject + '.')
         sys.exit('FATAL ERROR!')

--- a/bin/createInhouseSamplesheetFromGS.py
+++ b/bin/createInhouseSamplesheetFromGS.py
@@ -294,20 +294,20 @@ for row in gsReader:
     if gsSampleProcessStepID in gsSamplesheetDataHashmap:
         logging.critical('sampleProcessStepID ' + gsSampleProcessStepID + ' is not uniq in project ' + gsProject + '.')
         sys.exit('FATAL ERROR!')
-    try:
-        #
-        # Example data structure of gsSamplesheetDataHashmap:
-        # defaultdict(<type 'dict'>, {
-        #    '123456': {
-        #        'project': 'QXTR_426-Exoom_v1', 'GS_ID': '103373-032-059', 
-        #        'FastQs': [{'lane': '7', 'sequencingStartDate': '181128', 'run': '0363', 'sequencer': 'K00296', 'flowcell': 'H2TGVBBXY', 'barcodes': 'CTCTCTAC-AGAGGATA'}, 
-        #                   {'lane': '8', 'sequencingStartDate': '181128', 'run': '0364', 'sequencer': 'K00296', 'flowcell': 'HYKGJBBXX', 'barcodes': 'CTCTCTAC-AGAGGATA'}]},
-        #    '789012': {
-        #        'project': 'QXTR_426-Exoom_v1', 'GS_ID': '103373-032-058', 
-        #        'FastQs': [{'lane': '7', 'sequencingStartDate': '181128', 'run': '0363', 'sequencer': 'K00296', 'flowcell': 'H2TGVBBXY', 'barcodes': 'CAGAGAGG-TCTACTCT'}, 
-        #                   {'lane': '8', 'sequencingStartDate': '181128', 'run': '0364', 'sequencer': 'K00296', 'flowcell': 'HYKGJBBXX', 'barcodes': 'CAGAGAGG-TCTACTCT'}]}}
-        #
-        if gsBarcodesAndGenomeScanID in gsFilenameDataHashmap:
+    #
+    # Example data structure of gsSamplesheetDataHashmap:
+    # defaultdict(<type 'dict'>, {
+    #    '123456': {
+    #        'project': 'QXTR_426-Exoom_v1', 'GS_ID': '103373-032-059', 
+    #        'FastQs': [{'lane': '7', 'sequencingStartDate': '181128', 'run': '0363', 'sequencer': 'K00296', 'flowcell': 'H2TGVBBXY', 'barcodes': 'CTCTCTAC-AGAGGATA'}, 
+    #                   {'lane': '8', 'sequencingStartDate': '181128', 'run': '0364', 'sequencer': 'K00296', 'flowcell': 'HYKGJBBXX', 'barcodes': 'CTCTCTAC-AGAGGATA'}]},
+    #    '789012': {
+    #        'project': 'QXTR_426-Exoom_v1', 'GS_ID': '103373-032-058', 
+    #        'FastQs': [{'lane': '7', 'sequencingStartDate': '181128', 'run': '0363', 'sequencer': 'K00296', 'flowcell': 'H2TGVBBXY', 'barcodes': 'CAGAGAGG-TCTACTCT'}, 
+    #                   {'lane': '8', 'sequencingStartDate': '181128', 'run': '0364', 'sequencer': 'K00296', 'flowcell': 'HYKGJBBXX', 'barcodes': 'CAGAGAGG-TCTACTCT'}]}}
+    #
+    if gsBarcodesAndGenomeScanID in gsFilenameDataHashmap:
+        try:
             gsSamplesheetDataHashmap[gsSampleProcessStepID] = {
                 'project': gsProject, 'GS_ID': gsGenomeScanID,
                 'FastQs': gsFilenameDataHashmap[gsBarcodesAndGenomeScanID]
@@ -317,12 +317,12 @@ for row in gsReader:
             #pp = pprint.PrettyPrinter(indent=4)
             #pp.pprint(gsSamplesheetDataHashmap)
             #pp.pprint('#####################################################')
-        else:
+        except:
             logging.critical('Meta data parsed from original FastQ filenames as supplied by GenomeScan missing for sample ' + gsGenomeScanID + ' with barcodes ' + row['Index1'] + '-' + row['Index2'] + ' from project ' + gsProject + '.')
-            logging.critical('Check if the barcodes in the samplesheets match with the barcodes in the FastQ files for ' + gsGenomeScanID + '.')
             sys.exit('FATAL ERROR!')
-    except:
+    else:
         logging.critical('Meta data parsed from original FastQ filenames as supplied by GenomeScan missing for sample ' + gsGenomeScanID + ' with barcodes ' + row['Index1'] + '-' + row['Index2'] + ' from project ' + gsProject + '.')
+        logging.critical('Check if the barcodes in the samplesheets match with the barcodes in the FastQ files for ' + gsGenomeScanID + '.')
         sys.exit('FATAL ERROR!')
 gsSamplesheetFileHandle.close()
 #

--- a/bin/createInhouseSamplesheetFromGS.py
+++ b/bin/createInhouseSamplesheetFromGS.py
@@ -238,10 +238,10 @@ else:
 #
 gsFilenameDataHashmap = makeOriginalFilenameHashmap(checksumsFilePath)
 # For debugging data structure only:
-import pprint
-pp = pprint.PrettyPrinter(indent=4)
-pp.pprint(gsFilenameDataHashmap)
-pp.pprint('=====================================================')
+#import pprint
+#pp = pprint.PrettyPrinter(indent=4)
+#pp.pprint(gsFilenameDataHashmap)
+#pp.pprint('=====================================================')
 
 #
 # Combine GS samplesheet with original filename information form gsFilenameDataHashmap.
@@ -291,7 +291,7 @@ for row in gsReader:
     gsProjects.append(gsProject)
     gsBarcodesAndGenomeScanID = row['Index1'] + '-' + row['Index2'] + '-' + gsGenomeScanID
     logging.debug('Compiled gsBarcodesAndGenomeScanID key ' + gsBarcodesAndGenomeScanID + ' for lookup of values in gsFilenameDataHashmap.')
-    if gsSamplesheetDataHashmap.has_key(gsSampleProcessStepID):
+    if gsSampleProcessStepID in gsSamplesheetDataHashmap:
         logging.critical('sampleProcessStepID ' + gsSampleProcessStepID + ' is not uniq in project ' + gsProject + '.')
         sys.exit('FATAL ERROR!')
     try:
@@ -307,15 +307,20 @@ for row in gsReader:
         #        'FastQs': [{'lane': '7', 'sequencingStartDate': '181128', 'run': '0363', 'sequencer': 'K00296', 'flowcell': 'H2TGVBBXY', 'barcodes': 'CAGAGAGG-TCTACTCT'}, 
         #                   {'lane': '8', 'sequencingStartDate': '181128', 'run': '0364', 'sequencer': 'K00296', 'flowcell': 'HYKGJBBXX', 'barcodes': 'CAGAGAGG-TCTACTCT'}]}}
         #
-        gsSamplesheetDataHashmap[gsSampleProcessStepID] = {
-            'project': gsProject, 'GS_ID': gsGenomeScanID,
-            'FastQs': gsFilenameDataHashmap[gsBarcodesAndGenomeScanID]
-        }
-        # For debugging data structure only:
-        import pprint
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(gsSamplesheetDataHashmap)
-        pp.pprint('#####################################################')
+        if gsBarcodesAndGenomeScanID in gsFilenameDataHashmap:
+            gsSamplesheetDataHashmap[gsSampleProcessStepID] = {
+                'project': gsProject, 'GS_ID': gsGenomeScanID,
+                'FastQs': gsFilenameDataHashmap[gsBarcodesAndGenomeScanID]
+            }
+            # For debugging data structure only:
+            #import pprint
+            #pp = pprint.PrettyPrinter(indent=4)
+            #pp.pprint(gsSamplesheetDataHashmap)
+            #pp.pprint('#####################################################')
+        else:
+            logging.critical('Meta data parsed from original FastQ filenames as supplied by GenomeScan missing for sample ' + gsGenomeScanID + ' with barcodes ' + row['Index1'] + '-' + row['Index2'] + ' from project ' + gsProject + '.')
+            logging.critical('Check if the barcodes in the samplesheets match with the barcodes in the FastQ files for ' + gsGenomeScanID + '.')
+            sys.exit('FATAL ERROR!')
     except:
         logging.critical('Meta data parsed from original FastQ filenames as supplied by GenomeScan missing for sample ' + gsGenomeScanID + ' with barcodes ' + row['Index1'] + '-' + row['Index2'] + ' from project ' + gsProject + '.')
         sys.exit('FATAL ERROR!')

--- a/bin/createInhouseSamplesheetFromGS.py
+++ b/bin/createInhouseSamplesheetFromGS.py
@@ -42,6 +42,7 @@ def printNewSamplesheet(_projectSamplesheetPath, _gsSamplesheetDataHashmap, _sam
         _newRows.append(_headers)
         for _row in _reader:
             _sampleProcessStepID = _row['sampleProcessStepID'] # Uniquely identifies a sample.
+            logging.debug('Found sampleProcessStepID ' + _sampleProcessStepID + '; starting lookup of additional sample meta data in _gsSamplesheetDataHashmap ...')
             #
             # Try to create new rows: one for each flowcell-lane combination for each sample (=sampleProcessStepID).
             #

--- a/bin/processGsRawData.sh
+++ b/bin/processGsRawData.sh
@@ -690,7 +690,6 @@ function processSamplesheetsAndMoveConvertedData() {
 	# shellcheck disable=SC2153
 	printf '%s\n' "${_runDir},${GROUP},started,,,${timeStamp}" \
 		>> "${JOB_CONTROLE_FILE_BASE}.trace_post_overview.csv"
-
 	#
 	# Cleanup uploaded samplesheets per project.
 	#


### PR DESCRIPTION
* After sanity check: continue with separate converted GS samplesheet as opposed to using in place conversion, which may get lost due to yet another rsync from a data staging server using `pullRawDataFromDS.sh` before `processGsRawData.sh` has finished processing a batch.
* Added additional logging for log level debug.
* Added additional check when a GS_ID + barcodes combination has no associated FastQ files at all, which would otherwise result in an "empty" samplesheet with only a header line. This will now trigger a fatal error.