### PR TITLE
Bugfix for critical error message to report a mismatch in number of samples in samplesheets.

### DIFF
--- a/bin/createInhouseSamplesheetFromGS.py
+++ b/bin/createInhouseSamplesheetFromGS.py
@@ -349,7 +349,7 @@ for project in (uniqProjects):
         if (projectCounts[project] == (len(open(projectSamplesheetPath).readlines())-1)):
             logging.debug('Number of samples in GS samplesheet (' + str(projectCounts[project]) + ') is the same as in inhouse samplesheet for project: ' + project + '.')
         else:
-            logging.critical('Number of samples in GS samplesheet (' + str(projectCounts[project]) + ') is NOT the same as in inhouse Project (' + (len(open(projectSamplesheetPath).readlines())-1) + ' for project ' + project + '.')
+            logging.critical('Number of samples in GS samplesheet (' + str(projectCounts[project]) + ') is NOT the same as in inhouse Project (' + str(len(open(projectSamplesheetPath).readlines())-1) + ') for project ' + project + '.')
             sys.exit('FATAL ERROR!')
         #
         # Create new complete samplesheet.


### PR DESCRIPTION
This prevents this error when trying to report an error: 
```
Traceback (most recent call last):
  File "/apps/software/NGS_Automated/3.3.0-bare/bin/createInhouseSamplesheetFromGS.py", line 352, in <module>
    logging.critical('Number of samples in GS samplesheet (' + str(projectCounts[project]) + ') is NOT the same as in inhouse Project (' + (len(open(projectSamplesheetPath).readlines())-1) + ' for project ' + project + '.')
TypeError: cannot concatenate 'str' and 'int' objects
```
