### PR TITLE
Create extra log file with list of files at the moment we signal an upload is complete.

### DIFF
--- a/bin/pullRawDataFromDS.sh
+++ b/bin/pullRawDataFromDS.sh
@@ -215,6 +215,9 @@ else
 			if rsync "${HOSTNAME_DATA_STAGING}:${GENOMESCAN_HOME_DIR}/${gsBatch}/${gsBatch}.finished" 2>/dev/null
 			then
 				gsBatchUploadCompleted='true'
+				logTimeStamp=$(date '+%Y-%m-%d-T%H%M')
+				rsync "${HOSTNAME_DATA_STAGING}:${GENOMESCAN_HOME_DIR}/${gsBatch}" \
+					> "/groups/${GROUP}/${TMP_LFS}/logs/${gsBatch}/${gsBatch}.uploadCompletedListing_${logTimeStamp}.log"
 			fi
 			#
 			# Rsync everything but the .finished file: may be incompletely uploaded batch,


### PR DESCRIPTION
Attempt to figure out what cause the "No GS samplesheet present" error.