### PR TITLE
Improved bin/copyProjectDataToPrm.sh

### DIFF
--- a/bin/copyProjectDataToPrm.sh
+++ b/bin/copyProjectDataToPrm.sh
@@ -184,7 +184,7 @@ function rsyncProjectRun() {
 				if [[ "${_sampleType}" == 'GAP' ]]
 				then
 					log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "_sampleType is GAP. Making symlinks for DiagnosticOutput folder."
-					windowsPathDelimeter='\'
+					windowsPathDelimeter='\\'
 					linuxPathDelimeter='/'
 					#
 					# Create symlinks for PennCNV files per sample (new style).
@@ -194,6 +194,7 @@ function rsyncProjectRun() {
 					then
 						mapfile -t pennCNVFiles < <(find "${PRM_ROOT_DIR}/projects/${_project}/${_run}/results/PennCNV_reports/" -name "*.txt")
 						log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "Number of PennCNV files: ${#pennCNVFiles[@]}."
+						#shellcheck disable=SC2153
 						mkdir -p "/groups/${GROUP}/${DAT_LFS}/DiagnosticOutput/${_project}/"
 						for pennCNV in "${pennCNVFiles[@]}"
 						do

--- a/bin/copyProjectDataToPrm.sh
+++ b/bin/copyProjectDataToPrm.sh
@@ -184,6 +184,7 @@ function rsyncProjectRun() {
 				if [[ "${_sampleType}" == 'GAP' ]]
 				then
 					log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "_sampleType is GAP. Making symlinks for DiagnosticOutput folder."
+					# shellcheck disable=SC1003 # No, we are not escaping a '
 					windowsPathDelimeter='\\'
 					linuxPathDelimeter='/'
 					#

--- a/etc/chaperone.cfg
+++ b/etc/chaperone.cfg
@@ -12,3 +12,7 @@ sourceServerFQDNsecondary='gattaca02.gcc.rug.nl'
 sourceServerFQDNprimary='gattaca01.gcc.rug.nl'
 genomeScanCluster='zinc-finger.gcc.rug.nl'
 genomeScanClusterTmp='tmp05'
+declare -A SMB_SHARE_NAMES=(
+	['umcg-gap']='\\zkh\appdata\medgen\leucinezipper'
+	['umcg-gsad']='\\zkh\appdata\medgen\leucinezipper'
+)

--- a/etc/coenzyme.cfg
+++ b/etc/coenzyme.cfg
@@ -12,3 +12,7 @@ sourceServerFQDNsecondary='gattaca01.gcc.rug.nl'
 sourceServerFQDNprimary='gattaca02.gcc.rug.nl'
 genomeScanCluster='zinc-finger.gcc.rug.nl'
 genomeScanClusterTmp='tmp05'
+declare -A SMB_SHARE_NAMES=(
+	['umcg-gap']='\\zkh\appdata\medgen\zincfinger'
+	['umcg-gsad']='\\zkh\appdata\medgen\zincfinger'
+)


### PR DESCRIPTION
* Will work on _Zinc-Finger/coenzyme_ too: no hardcoded SMB share name/path that only works for _Leucine-Zipper/chaperone_
*  More ShellCheck compliant: disabling several ShellCheck errors is no longer required.